### PR TITLE
doc: fix docker hub url

### DIFF
--- a/docs/modules/ROOT/pages/install.adoc
+++ b/docs/modules/ROOT/pages/install.adoc
@@ -180,7 +180,7 @@ NOTE: The `jreleaser` command will be automatically executed inside `/workspace`
 You may also need to map environment variables to the container, such as `JRELEASER_PROJECT_VERSION`,
 `JRELEASER_GITHUB_TOKEN`, or others depending on your setup. Refer to the xref:configuration:index.adoc[] pages.
 
-You can find the tag listing link:hub.docker.com/r/jreleaser/jreleaser-slim/tags[here].
+You can find the tag listing link:https://hub.docker.com/r/jreleaser/jreleaser-slim/tags[here].
 
 == Maven
 Configure the xref:tools:jreleaser-maven.adoc[jreleaser-maven-plugin] in your POM file


### PR DESCRIPTION
the current URL leads to a non-existent page:
![image](https://user-images.githubusercontent.com/100741/120775959-00eda180-c524-11eb-8bba-89e1df3697b4.png)
