### PR TITLE
Fix indentation of `previousTagName` in Git doc

### DIFF
--- a/docs/modules/configuration/partials/release/yaml/common-head.adoc
+++ b/docs/modules/configuration/partials/release/yaml/common-head.adoc
@@ -58,11 +58,11 @@ endif::gitservice_api[]
     # icon:dot-circle[] icon:eye-slash[] icon:file-alt[]
     tagName: v1.0.0
 
-  # The tag to compare against the release tag. Is used to fetch all commits between those tags.
-  # May define a `JRELEASER_PREVIOUS_TAG_NAME` environment variable instead.
-  # If left unspecified, will use the previous logical tag of `tagName`.
-  # icon:dot-circle[] icon:eye-slash[]
-  previousTagName = "v0.9.0"
+    # The tag to compare against the release tag. Is used to fetch all commits between those tags.
+    # May define a `JRELEASER_PREVIOUS_TAG_NAME` environment variable instead.
+    # If left unspecified, will use the previous logical tag of `tagName`.
+    # icon:dot-circle[] icon:eye-slash[]
+    previousTagName = "v0.9.0"
 
     # The name of the release.
     # If left unspecified, will use `Release {{tagName}}`.


### PR DESCRIPTION
Not rocket science but cleaner.