### PR TITLE
Update Jbang instructions

### DIFF
--- a/docs/modules/ROOT/pages/install.adoc
+++ b/docs/modules/ROOT/pages/install.adoc
@@ -14,7 +14,6 @@ Windows::
 --
 *JBang*
 
-Requires Java 8
 [source]
 ----
 // Download, cache, and run
@@ -35,7 +34,6 @@ Linux::
 --
 *JBang*
 
-Requires Java 8
 [source]
 ----
 // Download, cache, and run
@@ -71,7 +69,6 @@ Mac::
 --
 *JBang*
 
-Requires Java 8
 [source]
 ----
 // Download, cache, and run
@@ -130,7 +127,6 @@ scoop install jreleaser
 
 *JBang*
 
-Requires Java 8
 [source]
 ----
 // Download, cache, and run
@@ -181,7 +177,6 @@ brew install jreleaser/tap/jreleaser
 
 *JBang*
 
-Requires Java 8
 [source]
 ----
 // Download, cache, and run
@@ -265,7 +260,6 @@ brew install jreleaser/tap/jreleaser
 
 *JBang*
 
-Requires Java 8
 [source]
 ----
 // Download, cache, and run


### PR DESCRIPTION
Removed "Required Java 8" from the Jbang instructions as this not really necessary given the fact Jbang can install Java when needed.
