### PR TITLE
Sonatype Snapshot URL is not correct

### DIFF
--- a/docs/modules/reference/pages/deploy/maven/nexus2.adoc
+++ b/docs/modules/reference/pages/deploy/maven/nexus2.adoc
@@ -2,7 +2,7 @@
 :deployer_id:   nexus2
 :deployer_name: Nexus2
 :deployer_url:  pass:[https://s01.oss.sonatype.org/service/local]
-:deployer_snapshot_url: pass:[https://s01.oss.sonatype.org/content/repositories/snapshot]
+:deployer_snapshot_url: pass:[https://s01.oss.sonatype.org/content/repositories/snapshots/]
 :default_auth:  BASIC
 :deployer_sys_key: nexus2
 :deployer_env_key: NEXUS2


### PR DESCRIPTION
- Snapshot URL is changed from /content/repositories/snapshot to /content/repositories/snapshots/. The original one shown: 404 - Repository with ID="snapshot" not found

<!-- Please target the `development` branch -->

<!--- The issue this PR addresses -->
Fixes #56
