### PR TITLE
Update jreleaser-cli.adoc, fix typo

### DIFF
--- a/docs/modules/tools/pages/jreleaser-cli.adoc
+++ b/docs/modules/tools/pages/jreleaser-cli.adoc
@@ -59,7 +59,7 @@ The following settings may also be specified via environment variables
 |                         | JRELEASER_DEFAULT_GIT_REMOTE      | origin
 |===
 
-`JRELEASER_SELECT_PLATFORMs` and `JRELEASER_REJECT_PLATFORMs` may define a command separated list of values such as
+`JRELEASER_SELECT_PLATFORMs` and `JRELEASER_REJECT_PLATFORMs` may define a comma-separated list of values such as
 `osx-x86_64,linux-x86_64`.
 
 These additional environment variables are supported as well:


### PR DESCRIPTION
Fix typo in JReleaser CLI description