### PR TITLE
Fix scriptHook maven example and typo in section 'Output'

### DIFF
--- a/docs/modules/reference/pages/hooks/script.adoc
+++ b/docs/modules/reference/pages/hooks/script.adoc
@@ -360,7 +360,7 @@ Maven::
         icon:dot-circle[]
       -->
       <before>
-        <commandHook>
+        <scriptHook>
           <!--
             Let the release continue if the hook fails.
             Defaults to `false`.
@@ -416,7 +416,7 @@ Maven::
             icon:dot-circle[]
           -->
           <filter>
-            <includes>release</include>
+            <includes>release</includes>
             <excludes>publish</excludes>
           </filter>
 
@@ -429,7 +429,7 @@ Maven::
             <platform>linux</platform>
             <platform>!windows</platform>
           </platforms>
-        </commandHook>
+        </scriptHook>
       </before>
     </script>
   </hooks>
@@ -698,7 +698,7 @@ NOTE: Use quotes around name templates if their evaluation may result in an empt
 
 == Output
 
-Command hooks have the option to provide key/value pairs as input for other steps in the current workflow. Simply
+Script hooks have the option to provide key/value pairs as input for other steps in the current workflow. Simply
 use `JRELEASER_OUTPUT:` as prefix in the script's output followed by `key=value`. For example, the following configuration
 adds a key named `foo` with a value `bar` before the `changelog` step is invoked:
 


### PR DESCRIPTION
Fixing minor typos in the script hook chapter.