### PR TITLE
Fix syntax in maven deployer guide for JReleaser Gradle

### DIFF
--- a/docs/modules/examples/pages/maven/maven-central.adoc
+++ b/docs/modules/examples/pages/maven/maven-central.adoc
@@ -151,7 +151,7 @@ jreleaser {
   deploy {
     maven {
       nexus2 {
-        maven-central {
+        'maven-central' {
           active = 'ALWAYS'
           url = '{deployer_url}'
           snapshotUrl = '{deployer_snapshot_url}'


### PR DESCRIPTION
When using the JReleaser Gradle plugin, the name of the Maven deploy configuration doesn't support dashes. Either avoid dashes or write the name within single quotes.

Fixes gh-73
