### PR TITLE
docs: correct property name for `overwrite` in Maven plugin

### DIFF
--- a/docs/modules/tools/pages/jreleaser-maven.adoc
+++ b/docs/modules/tools/pages/jreleaser-maven.adoc
@@ -162,7 +162,7 @@ Available parameters:
  * overwrite +
    Overwrite existing files. +
    Type: boolean +
-   User property: `jreleaser.init.overwrite`
+   User property: `jreleaser.template.overwrite`
 
  * skip +
    Skip execution. +


### PR DESCRIPTION
<!-- Please target the `development` branch -->

The name of the `overwrite` property for Maven plugin in documentation mismatches between documentation and [source code](https://github.com/jreleaser/jreleaser/blob/c5ef94404d5bc51b72300b27e6f4d663be03b183/plugins/jreleaser-maven-plugin/src/main/java/org/jreleaser/maven/plugin/JReleaserInitMojo.java#L67). I am proposing PR to change the documentation as changing source code could be breaking. Although based on my intuition the source code should change as it is the only parameter name that is not prefixed with `jrelease.init`
