### PR TITLE
Update shadow link in single-jar documentation

### DIFF
--- a/docs/modules/concepts/pages/distributions/single-jar.adoc
+++ b/docs/modules/concepts/pages/distributions/single-jar.adoc
@@ -19,7 +19,7 @@ Make sure the JAR is executable by setting the `Main-Class` manifest entry.
 
 .Gradle
 
- * link:https://imperceptiblethoughts.com/shadow/introduction/[shadow]: packages a JAR and its dependencies as
+ * link:https://gradleup.com/shadow/[shadow]: packages a JAR and its dependencies as
  an uber-jar.
  * link:https://docs.gradle.org/current/userguide/java_plugin.html[java]: if the JAR has no additional dependencies.
 


### PR DESCRIPTION
The previous link does not work any longer and ends up on a shady website.
