### PR TITLE
Fix GraalVM Native Image note

### DIFF
--- a/docs/modules/concepts/pages/distributions/binary.adoc
+++ b/docs/modules/concepts/pages/distributions/binary.adoc
@@ -70,7 +70,7 @@ Gradle plugins that can create such binaries. The distribution should be package
 contain a root entry, typically following the name of the archive, thus if the archive is named `app-1.2.3.zip` the root
 entry should be `app-1.2.3`.
 
-NOTE: You must an extra property named `graalVMNativeImage` to the distribution.
+NOTE: You must add an extra property named `graalVMNativeImage` to the distribution.
 
 .Maven
 


### PR DESCRIPTION
<!-- Please target the `development` branch -->

<!--- The issue this PR addresses -->
The verb add is missing in the GraalVM native image note section.